### PR TITLE
Enable extreme mode switch in settings menu

### DIFF
--- a/src/Glue/SettingsScreen.cpp
+++ b/src/Glue/SettingsScreen.cpp
@@ -6,6 +6,7 @@ extern "C" {
 #include "file.h"
 #include "sound2.h"
 #include "qd3d_support.h"
+#include "terrain.h"
 }
 
 #include <functional>
@@ -68,6 +69,7 @@ std::vector<SettingEntry> settings = {
 //		{&gGamePrefs.interpolationStyle , "Face Shading"      , nullptr, {"Flat", "Per-Pixel"} },
 //		{&gGamePrefs.opaqueWater        , "Water Alpha"       , nullptr, {"Translucent", "Opaque"}},
 		{&gGamePrefs.mainMenuHelp       , "Main Menu Help"      },
+		{&gGamePrefs.extreme            , "Extreme!"          , [](){SetProModeSettings(gGamePrefs.extreme); DisposeSupertileMemoryList(); InitTerrainManager();}},
 };
 
 static bool needFullRender = false;

--- a/src/Headers/structs.h
+++ b/src/Headers/structs.h
@@ -304,10 +304,11 @@ typedef struct
 	Boolean interpolationStyle;
 	Boolean vsync;
 	Boolean opaqueWater;
+	Boolean extreme;
 	Boolean	reserved[4];
 }PrefsType;
 
-#define PREFS_MAGIC "Nanosaur Prefs v2"
+#define PREFS_MAGIC "Nanosaur Prefs v3"
 
 #endif
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -69,42 +69,6 @@ static void FindGameData()
 	UseResFile(resFileRefNum);
 }
 
-static bool AskProMode()
-{
-	const SDL_MessageBoxButtonData buttons[] =
-	{
-		{ /* .flags, .buttonid, .text */        0, 0, (const char*)u8"Extreme!" },
-		{ SDL_MESSAGEBOX_BUTTON_RETURNKEY_DEFAULT, 1, (const char*)u8"Normal" },
-		{ SDL_MESSAGEBOX_BUTTON_ESCAPEKEY_DEFAULT, 2, (const char*)u8"Quit" },
-	};
-
-	const SDL_MessageBoxData messageboxdata =
-	{
-		SDL_MESSAGEBOX_INFORMATION,		// .flags
-		gSDLWindow,						// .window
-		(const char*)u8"Select Nanosaur difficulty",	// .title
-		(const char*)u8"Which version of Nanosaur would you like to play?", // .message
-		SDL_arraysize(buttons),			// .numbuttons
-		buttons,						// .buttons
-		nullptr							// .colorScheme
-	};
-
-	int buttonid;
-	if (SDL_ShowMessageBox(&messageboxdata, &buttonid) < 0)
-	{
-		throw Pomme::QuitRequest();
-	}
-
-	switch (buttonid) {
-		case 2: // quit
-			throw Pomme::QuitRequest();
-		case 0: // extreme
-			return true;
-		default: // normal
-			return false;
-	}
-}
-
 static const char* GetWindowTitle()
 {
 	static char windowTitle[256];
@@ -150,7 +114,6 @@ int CommonMain(int argc, const char** argv)
 	// Start the game
 	try
 	{
-		SetProModeSettings(AskProMode());
 		SDL_SetWindowTitle(gSDLWindow, GetWindowTitle());
 		GameMain();
 	}

--- a/src/System/Main.c
+++ b/src/System/Main.c
@@ -116,21 +116,6 @@ OSErr		iErr;
 	QD3D_Boot();
 
 
-			/* INIT SOME OF MY STUFF */
-			
-	InitTerrainManager();
-	InitSkeletonManager();
-	InitSoundTools();
-	Init3DMFManager();	
-		
-
-
-			/* INIT MORE MY STUFF */
-					
-	InitObjectManager();
-	InitSpriteManager();
-	
-	
 			/* INIT PREFERENCES */
 			
 	memset(&gGamePrefs, 0, sizeof(gGamePrefs));
@@ -145,9 +130,27 @@ OSErr		iErr;
 	gGamePrefs.vsync = true;
 	gGamePrefs.mainMenuHelp = true;
 	gGamePrefs.opaqueWater = false;
+	gGamePrefs.extreme = false;
 				
 	LoadPrefs(&gGamePrefs);							// attempt to read from prefs file
 	SetFullscreenMode();
+	SetProModeSettings(gGamePrefs.extreme);
+
+
+
+			/* INIT SOME OF MY STUFF */
+
+	InitTerrainManager();
+	InitSkeletonManager();
+	InitSoundTools();
+	Init3DMFManager();
+
+
+
+			/* INIT MORE MY STUFF */
+
+	InitObjectManager();
+	InitSpriteManager();
 					
 }
 


### PR DESCRIPTION
Rather than asking the user for mode on every launch, a preference can
be saved. This change also allows switching modes without relaunching
the game. Since terrain allocation depends on `PRO_MODE`, preferences
are loaded before initialization, and reallocation happens after
changing extreme mode setting.