### PR TITLE
Increase height at which easter egg is triggered

### DIFF
--- a/src/Player/MyGuy.c
+++ b/src/Player/MyGuy.c
@@ -818,7 +818,7 @@ static void UpdatePlayer(ObjNode *theNode)
 	
 			/* CHECK FOR EASTER EGG */
 			
-	if (gMyCoord.y > 2000)						// while riding birdie does this
+	if (gMyCoord.y > 1900)						// while riding birdie does this
 	{
 		GetCheatWeapons();
 		GetHealth(1);

--- a/src/Player/MyGuy.c
+++ b/src/Player/MyGuy.c
@@ -818,7 +818,7 @@ static void UpdatePlayer(ObjNode *theNode)
 	
 			/* CHECK FOR EASTER EGG */
 			
-	if (gMyCoord.y > 1500)						// while riding birdie does this
+	if (gMyCoord.y > 2000)						// while riding birdie does this
 	{
 		GetCheatWeapons();
 		GetHealth(1);


### PR DESCRIPTION
It's way too easy to accidentally trigger the easter egg when jumping from a mountain, and judging from the comment in the code, the intention was to trigger when riding the pterodactylus enemy.

The mountain height is 1074. When jumping, the player can reach about 1500, when jumping while standing on a jumping tyrannosaurus, the player can reach about 1800, so this pull request increases height at which easter egg is triggered to 1900.